### PR TITLE
Fixing syntax issues

### DIFF
--- a/xModuleAnalyzer-NET.ps1
+++ b/xModuleAnalyzer-NET.ps1
@@ -1,7 +1,7 @@
 ﻿param(
-	[string]$xModulePath = "multi-module-setup_net.txt",
-	[string]$fsaJarPath = "wss-unified-agent.jar",
-	[string]$c = "wss-unified-agent-EUA-net.config",
+	[string]$xModulePath,
+	[string]$fsaJarPath,
+	[string]$c,
 	[string]$d,
 	[string]$productName,
 	[switch]$viaDebug

--- a/xModuleAnalyzer-NET.sh
+++ b/xModuleAnalyzer-NET.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# For use with linux actions in https://github.com/whitesource-ft/ws-examples/tree/main/Prioritize/DotNet/Multi-Module
+# Modify SEARCHDIR & RELEASEDIR before running
+SEARCHDIR=$(pwd)
+RELEASEDIR='/bin/'
+
+# Finds all the .csproject file in the SEARCHDIR excluding names with build, test, host, & migration
+for csproject in  $(find $SEARCHDIR -type f \( -wholename "*.csproj" ! -wholename "*build*" ! -wholename "*test*" ! -wholename "*host*" ! -wholename "*migration*" \))
+
+do
+# For each .csproject found it takes the basename
+# example: fastapp.csproject becomes fastapp
+echo "Found" $csproject 
+CSPROJ=$(basename $csproject .csproj)
+
+# For each basename of the .csproject, find a dll with the same name in the release directory excluding names with build, test, host, & migration
+find ./ -type f \( -wholename "$RELEASEDIR$CSPROJ.dll" ! -wholename "*build*" ! -wholename "*test*" ! -wholename "*host*" ! -wholename "*migration*" \) -print >> multi-module.txt
+
+done
+
+# Writes all the found .dlls to a multi-module.txt file in the same directory 
+file="./multi-module.txt"
+dlls=`cat $file`
+
+for DLL in $dlls;
+
+do
+# For each dll in the above list, print out the variables that will be used for the prioritize scan
+echo "appPath:" $DLL
+DIR="$(echo "$DLL" | awk -F "$RELEASEDIR" '{print $1}')"
+echo "directory:" $DIR
+PROJECT=$(basename $DLL .dll)
+echo "PROJECT:" $PROJECT
+
+# Run a WSS prioritize scan for each DLL in the multi-module.txt file
+java -jar wss-unified-agent.jar -appPath "$DLL" -d "$DIR" -project "$PROJECT"
+
+done


### PR DESCRIPTION
$(PWD) is invalid in most Linux distros, changed it to $(pwd).

Also, the syntax in the awk command extracting $DIR from the $DLL failed in some cases and returned the whole string, leading to an execution specifying the -d flag with the full dll path.